### PR TITLE
Add .png extension to 16x16 and 32x32 icons urls

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,12 +3,12 @@
   "name": "Quiet Weather",
   "icons": [
     {
-      "src": "favicon-16x16",
+      "src": "favicon-16x16.png",
       "sizes": "16x16",
       "type": "image/png"
     },
     {
-      "src":"favicon-32x32",
+      "src":"favicon-32x32.png",
       "sizes":"32x32",
       "type": "image/png"
     },


### PR DESCRIPTION
The current ones return 404 once deployed.